### PR TITLE
Integrate pallets to support ERC20 bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- Added 3 new pallets for ERC20 integration. Source is [here](https://github.com/ChainSafe/chainbridge-substrate):
+	- pallet-chainbridge
+	- pallet-erc721
+	- pallet-erc20
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3862,12 +3862,15 @@ dependencies = [
  "pallet-babe",
  "pallet-balances",
  "pallet-cere-ddc",
+ "pallet-chainbridge",
  "pallet-collective",
  "pallet-contracts",
  "pallet-contracts-primitives",
  "pallet-contracts-rpc-runtime-api",
  "pallet-democracy",
  "pallet-elections-phragmen",
+ "pallet-erc20",
+ "pallet-erc721",
  "pallet-finality-tracker",
  "pallet-grandpa",
  "pallet-identity",
@@ -4336,6 +4339,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-chainbridge"
+version = "2.0.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-collective"
 version = "2.0.1"
 dependencies = [
@@ -4472,6 +4491,42 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "substrate-test-utils",
+]
+
+[[package]]
+name = "pallet-erc20"
+version = "2.0.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-chainbridge",
+ "pallet-erc721",
+ "parity-scale-codec",
+ "serde",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-erc721"
+version = "2.0.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-chainbridge",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -28,6 +28,7 @@ sp-inherents = { version = "2.0.0", default-features = false, path = "../../../p
 node-primitives = { version = "2.0.0", default-features = false, path = "../primitives" }
 sp-offchain = { version = "2.0.0", default-features = false, path = "../../../primitives/offchain" }
 sp-core = { version = "2.0.0", default-features = false, path = "../../../primitives/core" }
+sp-io = { version = "2.0.0", default-features = false, path = "../../../primitives/io" }
 sp-std = { version = "2.0.0", default-features = false, path = "../../../primitives/std" }
 sp-api = { version = "2.0.0", default-features = false, path = "../../../primitives/api" }
 sp-runtime = { version = "2.0.0", default-features = false, path = "../../../primitives/runtime" }
@@ -80,12 +81,12 @@ pallet-transaction-payment = { version = "2.0.0", default-features = false, path
 pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0", default-features = false, path = "../../../frame/transaction-payment/rpc/runtime-api/" }
 pallet-vesting = { version = "2.0.0", default-features = false, path = "../../../frame/vesting" }
 pallet-cere-ddc = { version = "2.0.0", default-features = false, path = "../../../frame/ddc-pallet" }
+pallet-chainbridge = { version = "2.0.0", default-features = false, path = "../../../frame/chainbridge" }
+pallet-erc721 = { version = "2.0.0", default-features = false, path = "../../../frame/erc721" }
+pallet-erc20 = { version = "2.0.0", default-features = false, path = "../../../frame/erc20" }
 
 [build-dependencies]
 wasm-builder-runner = { version = "1.0.5", package = "substrate-wasm-builder-runner", path = "../../../utils/wasm-builder-runner" }
-
-[dev-dependencies]
-sp-io = { version = "2.0.0", path = "../../../primitives/io" }
 
 [features]
 default = ["std"]
@@ -107,6 +108,9 @@ std = [
 	"pallet-elections-phragmen/std",
 	"frame-executive/std",
 	"pallet-cere-ddc/std",
+	"pallet-chainbridge/std",
+	"pallet-erc721/std",
+	"pallet-erc20/std",
 	"pallet-finality-tracker/std",
 	"pallet-grandpa/std",
 	"pallet-im-online/std",
@@ -121,6 +125,7 @@ std = [
 	"pallet-offences/std",
 	"pallet-proxy/std",
 	"sp-core/std",
+	"sp-io/std",
 	"pallet-randomness-collective-flip/std",
 	"sp-std/std",
 	"serde",

--- a/frame/chainbridge/Cargo.toml
+++ b/frame/chainbridge/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "pallet-chainbridge"
+version = "2.0.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+license = "Unlicense"
+homepage = "https://substrate.dev"
+repository = "https://github.com/paritytech/substrate/"
+description = "FRAME example pallet"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+serde = { version = "1.0.101", optional = true }
+codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false }
+frame-support = { version = "2.0.0", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0", default-features = false, path = "../system" }
+pallet-balances = { version = "2.0.0", default-features = false, path = "../balances" }
+sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
+sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/io" }
+sp-core = { version = "2.0.0", path = "../../primitives/core", default-features = false }
+
+frame-benchmarking = { version = "2.0.0", default-features = false, path = "../benchmarking", optional = true }
+
+[features]
+default = ["std"]
+std = [
+	"serde",
+	"codec/std",
+	"sp-runtime/std",
+	"frame-benchmarking/std",
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-balances/std",
+	"sp-io/std",
+	"sp-std/std"
+]
+runtime-benchmarks = ["frame-benchmarking"]

--- a/frame/chainbridge/src/lib.rs
+++ b/frame/chainbridge/src/lib.rs
@@ -621,6 +621,6 @@ impl<T: Trait> EnsureOrigin<T::Origin> for EnsureBridge<T> {
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn successful_origin() -> T::Origin {
-
+		T::Origin::from(system::RawOrigin::Root.into())
 	}
 }

--- a/frame/chainbridge/src/lib.rs
+++ b/frame/chainbridge/src/lib.rs
@@ -619,7 +619,8 @@ impl<T: Trait> EnsureOrigin<T::Origin> for EnsureBridge<T> {
         })
     }
 
-	fn successful_origin() -> <T as Trait>::Origin {
-		unimplemented!()
+	#[cfg(feature = "runtime-benchmarks")]
+	fn successful_origin() -> T::Origin {
+
 	}
 }

--- a/frame/chainbridge/src/lib.rs
+++ b/frame/chainbridge/src/lib.rs
@@ -1,0 +1,621 @@
+// Ensure we're `no_std` when compiling for Wasm.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use sp_std::marker::PhantomData;
+use frame_support::{
+	dispatch::{DispatchResult, IsSubType}, decl_module, decl_storage, decl_event, decl_error,
+	weights::{DispatchClass, ClassifyDispatch, WeighData, Weight, PaysFee, Pays, GetDispatchInfo},
+	ensure,
+	traits::{EnsureOrigin, Get},
+	Parameter,
+};
+use sp_std::prelude::*;
+use frame_system::{self as system, ensure_signed, ensure_root};
+use sp_core::U256;
+use codec::{Encode, Decode, EncodeLike};
+use sp_runtime::{
+	traits::{
+		SignedExtension, Bounded, SaturatedConversion, DispatchInfoOf, AccountIdConversion, Dispatchable,
+	},
+	transaction_validity::{
+		ValidTransaction, TransactionValidityError, InvalidTransaction, TransactionValidity,
+	},
+	ModuleId, RuntimeDebug,
+};
+
+mod mock;
+mod tests;
+
+const DEFAULT_RELAYER_THRESHOLD: u32 = 1;
+const MODULE_ID: ModuleId = ModuleId(*b"cb/bridg");
+
+pub type ChainId = u8;
+pub type DepositNonce = u64;
+pub type ResourceId = [u8; 32];
+
+/// Helper function to concatenate a chain ID and some bytes to produce a resource ID.
+/// The common format is (31 bytes unique ID + 1 byte chain ID).
+pub fn derive_resource_id(chain: u8, id: &[u8]) -> ResourceId {
+    let mut r_id: ResourceId = [0; 32];
+    r_id[31] = chain; // last byte is chain id
+    let range = if id.len() > 31 { 31 } else { id.len() }; // Use at most 31 bytes
+    for i in 0..range {
+        r_id[30 - i] = id[range - 1 - i]; // Ensure left padding for eth compatibility
+    }
+    return r_id;
+}
+
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
+pub enum ProposalStatus {
+    Initiated,
+    Approved,
+    Rejected,
+}
+
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
+pub struct ProposalVotes<AccountId, BlockNumber> {
+    pub votes_for: Vec<AccountId>,
+    pub votes_against: Vec<AccountId>,
+    pub status: ProposalStatus,
+    pub expiry: BlockNumber,
+}
+
+impl<A: PartialEq, B: PartialOrd + Default> ProposalVotes<A, B> {
+    /// Attempts to mark the proposal as approve or rejected.
+    /// Returns true if the status changes from active.
+    fn try_to_complete(&mut self, threshold: u32, total: u32) -> ProposalStatus {
+        if self.votes_for.len() >= threshold as usize {
+            self.status = ProposalStatus::Approved;
+            ProposalStatus::Approved
+        } else if total >= threshold && self.votes_against.len() as u32 + threshold > total {
+            self.status = ProposalStatus::Rejected;
+            ProposalStatus::Rejected
+        } else {
+            ProposalStatus::Initiated
+        }
+    }
+
+    /// Returns true if the proposal has been rejected or approved, otherwise false.
+    fn is_complete(&self) -> bool {
+        self.status != ProposalStatus::Initiated
+    }
+
+    /// Returns true if `who` has voted for or against the proposal
+    fn has_voted(&self, who: &A) -> bool {
+        self.votes_for.contains(&who) || self.votes_against.contains(&who)
+    }
+
+    /// Return true if the expiry time has been reached
+    fn is_expired(&self, now: B) -> bool {
+        self.expiry <= now
+    }
+}
+
+impl<AccountId, BlockNumber: Default> Default for ProposalVotes<AccountId, BlockNumber> {
+    fn default() -> Self {
+        Self {
+            votes_for: vec![],
+            votes_against: vec![],
+            status: ProposalStatus::Initiated,
+            expiry: BlockNumber::default(),
+        }
+    }
+}
+
+pub trait Trait: system::Trait {
+    type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+    /// Origin used to administer the pallet
+    type AdminOrigin: EnsureOrigin<Self::Origin>;
+    /// Proposed dispatchable call
+    type Proposal: Parameter + Dispatchable<Origin = Self::Origin> + EncodeLike + GetDispatchInfo;
+    /// The identifier for this chain.
+    /// This must be unique and must not collide with existing IDs within a set of bridged chains.
+    type ChainId: Get<ChainId>;
+
+    type ProposalLifetime: Get<Self::BlockNumber>;
+}
+
+decl_error! {
+    pub enum Error for Module<T: Trait> {
+        /// Relayer threshold not set
+        ThresholdNotSet,
+        /// Provided chain Id is not valid
+        InvalidChainId,
+        /// Relayer threshold cannot be 0
+        InvalidThreshold,
+        /// Interactions with this chain is not permitted
+        ChainNotWhitelisted,
+        /// Chain has already been enabled
+        ChainAlreadyWhitelisted,
+        /// Resource ID provided isn't mapped to anything
+        ResourceDoesNotExist,
+        /// Relayer already in set
+        RelayerAlreadyExists,
+        /// Provided accountId is not a relayer
+        RelayerInvalid,
+        /// Protected operation, must be performed by relayer
+        MustBeRelayer,
+        /// Relayer has already submitted some vote for this proposal
+        RelayerAlreadyVoted,
+        /// A proposal with these parameters has already been submitted
+        ProposalAlreadyExists,
+        /// No proposal with the ID was found
+        ProposalDoesNotExist,
+        /// Cannot complete proposal, needs more votes
+        ProposalNotComplete,
+        /// Proposal has either failed or succeeded
+        ProposalAlreadyComplete,
+        /// Lifetime of proposal has been exceeded
+        ProposalExpired,
+    }
+}
+
+decl_storage! {
+	trait Store for Module<T: Trait> as ChainBridge {
+		/// All whitelisted chains and their respective transaction counts
+		ChainNonces get(fn chains): map hasher(opaque_blake2_256) ChainId => Option<DepositNonce>;
+
+		/// Number of votes required for a proposal to execute
+		RelayerThreshold get(fn relayer_threshold): u32 = DEFAULT_RELAYER_THRESHOLD;
+
+		/// Tracks current relayer set
+		pub Relayers get(fn relayers): map hasher(opaque_blake2_256) T::AccountId => bool;
+
+		/// Number of relayers in set
+		pub RelayerCount get(fn relayer_count): u32;
+
+		/// All known proposals.
+		/// The key is the hash of the call and the deposit ID, to ensure it's unique.
+		pub Votes get(fn votes):
+			double_map hasher(opaque_blake2_256) ChainId, hasher(opaque_blake2_256) (DepositNonce, T::Proposal)
+			=> Option<ProposalVotes<T::AccountId, T::BlockNumber>>;
+
+		/// Utilized by the bridge software to map resource IDs to actual methods
+		pub Resources get(fn resources):
+			map hasher(opaque_blake2_256) ResourceId => Option<Vec<u8>>
+	}
+}
+
+decl_event!(
+	pub enum Event<T> where <T as frame_system::Trait>::AccountId {
+        /// Vote threshold has changed (new_threshold)
+        RelayerThresholdChanged(u32),
+        /// Chain now available for transfers (chain_id)
+        ChainWhitelisted(ChainId),
+        /// Relayer added to set
+        RelayerAdded(AccountId),
+        /// Relayer removed from set
+        RelayerRemoved(AccountId),
+        /// FunglibleTransfer is for relaying fungibles (dest_id, nonce, resource_id, amount, recipient, metadata)
+        FungibleTransfer(ChainId, DepositNonce, ResourceId, U256, Vec<u8>),
+        /// NonFungibleTransfer is for relaying NFTS (dest_id, nonce, resource_id, token_id, recipient, metadata)
+        NonFungibleTransfer(ChainId, DepositNonce, ResourceId, Vec<u8>, Vec<u8>, Vec<u8>),
+        /// GenericTransfer is for a generic data payload (dest_id, nonce, resource_id, metadata)
+        GenericTransfer(ChainId, DepositNonce, ResourceId, Vec<u8>),
+        /// Vote submitted in favour of proposal
+        VoteFor(ChainId, DepositNonce, AccountId),
+        /// Vot submitted against proposal
+        VoteAgainst(ChainId, DepositNonce, AccountId),
+        /// Voting successful for a proposal
+        ProposalApproved(ChainId, DepositNonce),
+        /// Voting rejected a proposal
+        ProposalRejected(ChainId, DepositNonce),
+        /// Execution of call succeeded
+        ProposalSucceeded(ChainId, DepositNonce),
+        /// Execution of call failed
+        ProposalFailed(ChainId, DepositNonce),
+    }
+);
+
+decl_module! {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        type Error = Error<T>;
+
+        const ChainIdentity: ChainId = T::ChainId::get();
+        const ProposalLifetime: T::BlockNumber = T::ProposalLifetime::get();
+        const BridgeAccountId: T::AccountId = MODULE_ID.into_account();
+
+        fn deposit_event() = default;
+
+        /// Sets the vote threshold for proposals.
+        ///
+        /// This threshold is used to determine how many votes are required
+        /// before a proposal is executed.
+        ///
+        /// # <weight>
+        /// - O(1) lookup and insert
+        /// # </weight>
+        #[weight = 195_000_000]
+        pub fn set_threshold(origin, threshold: u32) -> DispatchResult {
+            Self::ensure_admin(origin)?;
+            Self::set_relayer_threshold(threshold)
+        }
+
+        /// Stores a method name on chain under an associated resource ID.
+        ///
+        /// # <weight>
+        /// - O(1) write
+        /// # </weight>
+        #[weight = 195_000_000]
+        pub fn set_resource(origin, id: ResourceId, method: Vec<u8>) -> DispatchResult {
+            Self::ensure_admin(origin)?;
+            Self::register_resource(id, method)
+        }
+
+        /// Removes a resource ID from the resource mapping.
+        ///
+        /// After this call, bridge transfers with the associated resource ID will
+        /// be rejected.
+        ///
+        /// # <weight>
+        /// - O(1) removal
+        /// # </weight>
+        #[weight = 195_000_000]
+        pub fn remove_resource(origin, id: ResourceId) -> DispatchResult {
+            Self::ensure_admin(origin)?;
+            Self::unregister_resource(id)
+        }
+
+        /// Enables a chain ID as a source or destination for a bridge transfer.
+        ///
+        /// # <weight>
+        /// - O(1) lookup and insert
+        /// # </weight>
+        #[weight = 195_000_000]
+        pub fn whitelist_chain(origin, id: ChainId) -> DispatchResult {
+            Self::ensure_admin(origin)?;
+            Self::whitelist(id)
+        }
+
+        /// Adds a new relayer to the relayer set.
+        ///
+        /// # <weight>
+        /// - O(1) lookup and insert
+        /// # </weight>
+        #[weight = 195_000_000]
+        pub fn add_relayer(origin, v: T::AccountId) -> DispatchResult {
+            Self::ensure_admin(origin)?;
+            Self::register_relayer(v)
+        }
+
+        /// Removes an existing relayer from the set.
+        ///
+        /// # <weight>
+        /// - O(1) lookup and removal
+        /// # </weight>
+        #[weight = 195_000_000]
+        pub fn remove_relayer(origin, v: T::AccountId) -> DispatchResult {
+            Self::ensure_admin(origin)?;
+            Self::unregister_relayer(v)
+        }
+
+        /// Commits a vote in favour of the provided proposal.
+        ///
+        /// If a proposal with the given nonce and source chain ID does not already exist, it will
+        /// be created with an initial vote in favour from the caller.
+        ///
+        /// # <weight>
+        /// - weight of proposed call, regardless of whether execution is performed
+        /// # </weight>
+        #[weight = (call.get_dispatch_info().weight + 195_000_000, call.get_dispatch_info().class, Pays::Yes)]
+        pub fn acknowledge_proposal(origin, nonce: DepositNonce, src_id: ChainId, r_id: ResourceId, call: Box<<T as Trait>::Proposal>) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+            ensure!(Self::is_relayer(&who), Error::<T>::MustBeRelayer);
+            ensure!(Self::chain_whitelisted(src_id), Error::<T>::ChainNotWhitelisted);
+            ensure!(Self::resource_exists(r_id), Error::<T>::ResourceDoesNotExist);
+
+            Self::vote_for(who, nonce, src_id, call)
+        }
+
+        /// Commits a vote against a provided proposal.
+        ///
+        /// # <weight>
+        /// - Fixed, since execution of proposal should not be included
+        /// # </weight>
+        #[weight = 195_000_000]
+        pub fn reject_proposal(origin, nonce: DepositNonce, src_id: ChainId, r_id: ResourceId, call: Box<<T as Trait>::Proposal>) -> DispatchResult {
+            let who = ensure_signed(origin)?;
+            ensure!(Self::is_relayer(&who), Error::<T>::MustBeRelayer);
+            ensure!(Self::chain_whitelisted(src_id), Error::<T>::ChainNotWhitelisted);
+            ensure!(Self::resource_exists(r_id), Error::<T>::ResourceDoesNotExist);
+
+            Self::vote_against(who, nonce, src_id, call)
+        }
+
+        /// Evaluate the state of a proposal given the current vote threshold.
+        ///
+        /// A proposal with enough votes will be either executed or cancelled, and the status
+        /// will be updated accordingly.
+        ///
+        /// # <weight>
+        /// - weight of proposed call, regardless of whether execution is performed
+        /// # </weight>
+        #[weight = (prop.get_dispatch_info().weight + 195_000_000, prop.get_dispatch_info().class, Pays::Yes)]
+        pub fn eval_vote_state(origin, nonce: DepositNonce, src_id: ChainId, prop: Box<<T as Trait>::Proposal>) -> DispatchResult {
+            ensure_signed(origin)?;
+
+            Self::try_resolve_proposal(nonce, src_id, prop)
+        }
+    }
+}
+
+impl<T: Trait> Module<T> {
+    // *** Utility methods ***
+
+    pub fn ensure_admin(o: T::Origin) -> DispatchResult {
+        T::AdminOrigin::try_origin(o)
+            .map(|_| ())
+            .or_else(ensure_root)?;
+        Ok(())
+    }
+
+    /// Checks if who is a relayer
+    pub fn is_relayer(who: &T::AccountId) -> bool {
+        Self::relayers(who)
+    }
+
+    /// Provides an AccountId for the pallet.
+    /// This is used both as an origin check and deposit/withdrawal account.
+    pub fn account_id() -> T::AccountId {
+        MODULE_ID.into_account()
+    }
+
+    /// Asserts if a resource is registered
+    pub fn resource_exists(id: ResourceId) -> bool {
+        return Self::resources(id) != None;
+    }
+
+    /// Checks if a chain exists as a whitelisted destination
+    pub fn chain_whitelisted(id: ChainId) -> bool {
+        return Self::chains(id) != None;
+    }
+
+    /// Increments the deposit nonce for the specified chain ID
+    fn bump_nonce(id: ChainId) -> DepositNonce {
+        let nonce = Self::chains(id).unwrap_or_default() + 1;
+        <ChainNonces>::insert(id, nonce);
+        nonce
+    }
+
+    // *** Admin methods ***
+
+    /// Set a new voting threshold
+    pub fn set_relayer_threshold(threshold: u32) -> DispatchResult {
+        ensure!(threshold > 0, Error::<T>::InvalidThreshold);
+        <RelayerThreshold>::put(threshold);
+        Self::deposit_event(RawEvent::RelayerThresholdChanged(threshold));
+        Ok(())
+    }
+
+    /// Register a method for a resource Id, enabling associated transfers
+    pub fn register_resource(id: ResourceId, method: Vec<u8>) -> DispatchResult {
+        <Resources>::insert(id, method);
+        Ok(())
+    }
+
+    /// Removes a resource ID, disabling associated transfer
+    pub fn unregister_resource(id: ResourceId) -> DispatchResult {
+        <Resources>::remove(id);
+        Ok(())
+    }
+
+    /// Whitelist a chain ID for transfer
+    pub fn whitelist(id: ChainId) -> DispatchResult {
+        // Cannot whitelist this chain
+        ensure!(id != T::ChainId::get(), Error::<T>::InvalidChainId);
+        // Cannot whitelist with an existing entry
+        ensure!(
+            !Self::chain_whitelisted(id),
+            Error::<T>::ChainAlreadyWhitelisted
+        );
+        <ChainNonces>::insert(&id, 0);
+        Self::deposit_event(RawEvent::ChainWhitelisted(id));
+        Ok(())
+    }
+
+    /// Adds a new relayer to the set
+    pub fn register_relayer(relayer: T::AccountId) -> DispatchResult {
+        ensure!(
+            !Self::is_relayer(&relayer),
+            Error::<T>::RelayerAlreadyExists
+        );
+        <Relayers<T>>::insert(&relayer, true);
+        <RelayerCount>::mutate(|i| *i += 1);
+
+        Self::deposit_event(RawEvent::RelayerAdded(relayer));
+        Ok(())
+    }
+
+    /// Removes a relayer from the set
+    pub fn unregister_relayer(relayer: T::AccountId) -> DispatchResult {
+        ensure!(Self::is_relayer(&relayer), Error::<T>::RelayerInvalid);
+        <Relayers<T>>::remove(&relayer);
+        <RelayerCount>::mutate(|i| *i -= 1);
+        Self::deposit_event(RawEvent::RelayerRemoved(relayer));
+        Ok(())
+    }
+
+    // *** Proposal voting and execution methods ***
+
+    /// Commits a vote for a proposal. If the proposal doesn't exist it will be created.
+    fn commit_vote(
+        who: T::AccountId,
+        nonce: DepositNonce,
+        src_id: ChainId,
+        prop: Box<T::Proposal>,
+        in_favour: bool,
+    ) -> DispatchResult {
+        let now = <frame_system::Module<T>>::block_number();
+        let mut votes = match <Votes<T>>::get(src_id, (nonce, prop.clone())) {
+            Some(v) => v,
+            None => {
+                let mut v = ProposalVotes::default();
+                v.expiry = now + T::ProposalLifetime::get();
+                v
+            }
+        };
+
+        // Ensure the proposal isn't complete and relayer hasn't already voted
+        ensure!(!votes.is_complete(), Error::<T>::ProposalAlreadyComplete);
+        ensure!(!votes.is_expired(now), Error::<T>::ProposalExpired);
+        ensure!(!votes.has_voted(&who), Error::<T>::RelayerAlreadyVoted);
+
+        if in_favour {
+            votes.votes_for.push(who.clone());
+            Self::deposit_event(RawEvent::VoteFor(src_id, nonce, who.clone()));
+        } else {
+            votes.votes_against.push(who.clone());
+            Self::deposit_event(RawEvent::VoteAgainst(src_id, nonce, who.clone()));
+        }
+
+        <Votes<T>>::insert(src_id, (nonce, prop.clone()), votes.clone());
+
+        Ok(())
+    }
+
+    /// Attempts to finalize or cancel the proposal if the vote count allows.
+    fn try_resolve_proposal(
+        nonce: DepositNonce,
+        src_id: ChainId,
+        prop: Box<T::Proposal>,
+    ) -> DispatchResult {
+        if let Some(mut votes) = <Votes<T>>::get(src_id, (nonce, prop.clone())) {
+            let now = <frame_system::Module<T>>::block_number();
+            ensure!(!votes.is_complete(), Error::<T>::ProposalAlreadyComplete);
+            ensure!(!votes.is_expired(now), Error::<T>::ProposalExpired);
+
+            let status = votes.try_to_complete(<RelayerThreshold>::get(), <RelayerCount>::get());
+            <Votes<T>>::insert(src_id, (nonce, prop.clone()), votes.clone());
+
+            match status {
+                ProposalStatus::Approved => Self::finalize_execution(src_id, nonce, prop),
+                ProposalStatus::Rejected => Self::cancel_execution(src_id, nonce),
+                _ => Ok(()),
+            }
+        } else {
+            Err(Error::<T>::ProposalDoesNotExist)?
+        }
+    }
+
+    /// Commits a vote in favour of the proposal and executes it if the vote threshold is met.
+    fn vote_for(
+        who: T::AccountId,
+        nonce: DepositNonce,
+        src_id: ChainId,
+        prop: Box<T::Proposal>,
+    ) -> DispatchResult {
+        Self::commit_vote(who, nonce, src_id, prop.clone(), true)?;
+        Self::try_resolve_proposal(nonce, src_id, prop)
+    }
+
+    /// Commits a vote against the proposal and cancels it if more than (relayers.len() - threshold)
+    /// votes against exist.
+    fn vote_against(
+        who: T::AccountId,
+        nonce: DepositNonce,
+        src_id: ChainId,
+        prop: Box<T::Proposal>,
+    ) -> DispatchResult {
+        Self::commit_vote(who, nonce, src_id, prop.clone(), false)?;
+        Self::try_resolve_proposal(nonce, src_id, prop)
+    }
+
+    /// Execute the proposal and signals the result as an event
+    fn finalize_execution(
+        src_id: ChainId,
+        nonce: DepositNonce,
+        call: Box<T::Proposal>,
+    ) -> DispatchResult {
+        Self::deposit_event(RawEvent::ProposalApproved(src_id, nonce));
+        call.dispatch(frame_system::RawOrigin::Signed(Self::account_id()).into())
+            .map(|_| ())
+            .map_err(|e| e.error)?;
+        Self::deposit_event(RawEvent::ProposalSucceeded(src_id, nonce));
+        Ok(())
+    }
+
+    /// Cancels a proposal.
+    fn cancel_execution(src_id: ChainId, nonce: DepositNonce) -> DispatchResult {
+        Self::deposit_event(RawEvent::ProposalRejected(src_id, nonce));
+        Ok(())
+    }
+
+    /// Initiates a transfer of a fungible asset out of the chain. This should be called by another pallet.
+    pub fn transfer_fungible(
+        dest_id: ChainId,
+        resource_id: ResourceId,
+        to: Vec<u8>,
+        amount: U256,
+    ) -> DispatchResult {
+        ensure!(
+            Self::chain_whitelisted(dest_id),
+            Error::<T>::ChainNotWhitelisted
+        );
+        let nonce = Self::bump_nonce(dest_id);
+        Self::deposit_event(RawEvent::FungibleTransfer(
+            dest_id,
+            nonce,
+            resource_id,
+            amount,
+            to,
+        ));
+        Ok(())
+    }
+
+    /// Initiates a transfer of a nonfungible asset out of the chain. This should be called by another pallet.
+    pub fn transfer_nonfungible(
+        dest_id: ChainId,
+        resource_id: ResourceId,
+        token_id: Vec<u8>,
+        to: Vec<u8>,
+        metadata: Vec<u8>,
+    ) -> DispatchResult {
+        ensure!(
+            Self::chain_whitelisted(dest_id),
+            Error::<T>::ChainNotWhitelisted
+        );
+        let nonce = Self::bump_nonce(dest_id);
+        Self::deposit_event(RawEvent::NonFungibleTransfer(
+            dest_id,
+            nonce,
+            resource_id,
+            token_id,
+            to,
+            metadata,
+        ));
+        Ok(())
+    }
+
+    /// Initiates a transfer of generic data out of the chain. This should be called by another pallet.
+    pub fn transfer_generic(
+        dest_id: ChainId,
+        resource_id: ResourceId,
+        metadata: Vec<u8>,
+    ) -> DispatchResult {
+        ensure!(
+            Self::chain_whitelisted(dest_id),
+            Error::<T>::ChainNotWhitelisted
+        );
+        let nonce = Self::bump_nonce(dest_id);
+        Self::deposit_event(RawEvent::GenericTransfer(
+            dest_id,
+            nonce,
+            resource_id,
+            metadata,
+        ));
+        Ok(())
+    }
+}
+
+/// Simple ensure origin for the bridge account
+pub struct EnsureBridge<T>(sp_std::marker::PhantomData<T>);
+impl<T: Trait> EnsureOrigin<T::Origin> for EnsureBridge<T> {
+    type Success = T::AccountId;
+    fn try_origin(o: T::Origin) -> Result<Self::Success, T::Origin> {
+        let bridge_id = MODULE_ID.into_account();
+        o.into().and_then(|o| match o {
+            system::RawOrigin::Signed(who) if who == bridge_id => Ok(bridge_id),
+            r => Err(T::Origin::from(r)),
+        })
+    }
+}

--- a/frame/chainbridge/src/lib.rs
+++ b/frame/chainbridge/src/lib.rs
@@ -619,7 +619,7 @@ impl<T: Trait> EnsureOrigin<T::Origin> for EnsureBridge<T> {
         })
     }
 
-	#[cfg(feature = "runtime-benchmarks")]
+//	#[cfg(feature = "runtime-benchmarks")]
 	fn successful_origin() -> T::Origin {
 		T::Origin::from(system::RawOrigin::Root.into())
 	}

--- a/frame/chainbridge/src/lib.rs
+++ b/frame/chainbridge/src/lib.rs
@@ -618,9 +618,4 @@ impl<T: Trait> EnsureOrigin<T::Origin> for EnsureBridge<T> {
             r => Err(T::Origin::from(r)),
         })
     }
-
-//	#[cfg(feature = "runtime-benchmarks")]
-	fn successful_origin() -> T::Origin {
-		T::Origin::from(system::RawOrigin::Root.into())
-	}
 }

--- a/frame/chainbridge/src/lib.rs
+++ b/frame/chainbridge/src/lib.rs
@@ -618,4 +618,8 @@ impl<T: Trait> EnsureOrigin<T::Origin> for EnsureBridge<T> {
             r => Err(T::Origin::from(r)),
         })
     }
+
+	fn successful_origin() -> <T as Trait>::Origin {
+		unimplemented!()
+	}
 }

--- a/frame/chainbridge/src/mock.rs
+++ b/frame/chainbridge/src/mock.rs
@@ -1,0 +1,160 @@
+#![cfg(test)]
+
+use super::*;
+
+use frame_support::{assert_ok, ord_parameter_types, parameter_types, weights::Weight};
+use frame_system::{self as system};
+use sp_core::H256;
+use sp_runtime::{
+    testing::Header,
+    traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, IdentityLookup},
+    Perbill,
+};
+
+use crate::{self as bridge, Trait};
+pub use pallet_balances as balances;
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: Weight = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::one();
+    pub const MaxLocks: u32 = 50;
+}
+
+impl frame_system::Trait for Test {
+    type BaseCallFilter = ();
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = BlockHashCount;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type DbWeight = ();
+    type BlockExecutionWeight = ();
+    type ExtrinsicBaseWeight = ();
+    type MaximumExtrinsicWeight = ();
+    type MaximumBlockLength = MaximumBlockLength;
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type Version = ();
+    // type ModuleToIndex = ();
+    type PalletInfo = ();
+    // type MaxLocks = MaxLocks;
+    type AccountData = pallet_balances::AccountData<u64>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+}
+
+parameter_types! {
+    pub const ExistentialDeposit: u64 = 1;
+}
+
+ord_parameter_types! {
+    pub const One: u64 = 1;
+}
+
+impl pallet_balances::Trait for Test {
+    type Balance = u64;
+    type DustRemoval = ();
+    type Event = Event;
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type WeightInfo = ();
+    type MaxLocks = ();
+}
+
+parameter_types! {
+    pub const TestChainId: u8 = 5;
+    pub const ProposalLifetime: u64 = 50;
+}
+
+impl Trait for Test {
+    type Event = Event;
+    type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+    type Proposal = Call;
+    type ChainId = TestChainId;
+    type ProposalLifetime = ProposalLifetime;
+}
+
+pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
+pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, u64, Call, ()>;
+
+frame_support::construct_runtime!(
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic
+    {
+        System: system::{Module, Call, Event<T>},
+        Balances: balances::{Module, Call, Storage, Config<T>, Event<T>},
+        Bridge: bridge::{Module, Call, Storage, Event<T>},
+    }
+);
+
+// pub const BRIDGE_ID: u64 =
+pub const RELAYER_A: u64 = 0x2;
+pub const RELAYER_B: u64 = 0x3;
+pub const RELAYER_C: u64 = 0x4;
+pub const ENDOWED_BALANCE: u64 = 100_000_000;
+pub const TEST_THRESHOLD: u32 = 2;
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    let bridge_id = ModuleId(*b"cb/bridg").into_account();
+    let mut t = frame_system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
+    pallet_balances::GenesisConfig::<Test> {
+        balances: vec![(bridge_id, ENDOWED_BALANCE)],
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+    let mut ext = sp_io::TestExternalities::new(t);
+    ext.execute_with(|| System::set_block_number(1));
+    ext
+}
+
+pub fn new_test_ext_initialized(
+    src_id: ChainId,
+    r_id: ResourceId,
+    resource: Vec<u8>,
+) -> sp_io::TestExternalities {
+    let mut t = new_test_ext();
+    t.execute_with(|| {
+        // Set and check threshold
+        assert_ok!(Bridge::set_threshold(Origin::root(), TEST_THRESHOLD));
+        assert_eq!(Bridge::relayer_threshold(), TEST_THRESHOLD);
+        // Add relayers
+        assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_A));
+        assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_B));
+        assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_C));
+        // Whitelist chain
+        assert_ok!(Bridge::whitelist_chain(Origin::root(), src_id));
+        // Set and check resource ID mapped to some junk data
+        assert_ok!(Bridge::set_resource(Origin::root(), r_id, resource));
+        assert_eq!(Bridge::resource_exists(r_id), true);
+    });
+    t
+}
+
+// Checks events against the latest. A contiguous set of events must be provided. They must
+// include the most recent event, but do not have to include every past event.
+pub fn assert_events(mut expected: Vec<Event>) {
+    let mut actual: Vec<Event> = system::Module::<Test>::events()
+        .iter()
+        .map(|e| e.event.clone())
+        .collect();
+
+    expected.reverse();
+
+    for evt in expected {
+        let next = actual.pop().expect("event expected");
+        assert_eq!(next, evt.into(), "Events don't match (actual,expected)");
+    }
+}

--- a/frame/chainbridge/src/tests.rs
+++ b/frame/chainbridge/src/tests.rs
@@ -1,0 +1,534 @@
+#![cfg(test)]
+
+use super::mock::{
+    assert_events, new_test_ext, Balances, Bridge, Call, Event, Origin, ProposalLifetime, System,
+    Test, TestChainId, ENDOWED_BALANCE, RELAYER_A, RELAYER_B, RELAYER_C, TEST_THRESHOLD,
+};
+use super::*;
+use crate::mock::new_test_ext_initialized;
+use frame_support::{assert_noop, assert_ok};
+
+#[test]
+fn derive_ids() {
+    let chain = 1;
+    let id = [
+        0x21, 0x60, 0x5f, 0x71, 0x84, 0x5f, 0x37, 0x2a, 0x9e, 0xd8, 0x42, 0x53, 0xd2, 0xd0, 0x24,
+        0xb7, 0xb1, 0x09, 0x99, 0xf4,
+    ];
+    let r_id = derive_resource_id(chain, &id);
+    let expected = [
+        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x21, 0x60, 0x5f, 0x71, 0x84, 0x5f,
+        0x37, 0x2a, 0x9e, 0xd8, 0x42, 0x53, 0xd2, 0xd0, 0x24, 0xb7, 0xb1, 0x09, 0x99, 0xf4, chain,
+    ];
+    assert_eq!(r_id, expected);
+}
+
+#[test]
+fn complete_proposal_approved() {
+    let mut prop = ProposalVotes {
+        votes_for: vec![1, 2],
+        votes_against: vec![3],
+        status: ProposalStatus::Initiated,
+        expiry: ProposalLifetime::get(),
+    };
+
+    prop.try_to_complete(2, 3);
+    assert_eq!(prop.status, ProposalStatus::Approved);
+}
+
+#[test]
+fn complete_proposal_rejected() {
+    let mut prop = ProposalVotes {
+        votes_for: vec![1],
+        votes_against: vec![2, 3],
+        status: ProposalStatus::Initiated,
+        expiry: ProposalLifetime::get(),
+    };
+
+    prop.try_to_complete(2, 3);
+    assert_eq!(prop.status, ProposalStatus::Rejected);
+}
+
+#[test]
+fn complete_proposal_bad_threshold() {
+    let mut prop = ProposalVotes {
+        votes_for: vec![1, 2],
+        votes_against: vec![],
+        status: ProposalStatus::Initiated,
+        expiry: ProposalLifetime::get(),
+    };
+
+    prop.try_to_complete(3, 2);
+    assert_eq!(prop.status, ProposalStatus::Initiated);
+
+    let mut prop = ProposalVotes {
+        votes_for: vec![],
+        votes_against: vec![1, 2],
+        status: ProposalStatus::Initiated,
+        expiry: ProposalLifetime::get(),
+    };
+
+    prop.try_to_complete(3, 2);
+    assert_eq!(prop.status, ProposalStatus::Initiated);
+}
+
+#[test]
+fn setup_resources() {
+    new_test_ext().execute_with(|| {
+        let id: ResourceId = [1; 32];
+        let method = "Pallet.do_something".as_bytes().to_vec();
+        let method2 = "Pallet.do_somethingElse".as_bytes().to_vec();
+
+        assert_ok!(Bridge::set_resource(Origin::root(), id, method.clone()));
+        assert_eq!(Bridge::resources(id), Some(method));
+
+        assert_ok!(Bridge::set_resource(Origin::root(), id, method2.clone()));
+        assert_eq!(Bridge::resources(id), Some(method2));
+
+        assert_ok!(Bridge::remove_resource(Origin::root(), id));
+        assert_eq!(Bridge::resources(id), None);
+    })
+}
+
+#[test]
+fn whitelist_chain() {
+    new_test_ext().execute_with(|| {
+        assert!(!Bridge::chain_whitelisted(0));
+
+        assert_ok!(Bridge::whitelist_chain(Origin::root(), 0));
+        assert_noop!(
+            Bridge::whitelist_chain(Origin::root(), TestChainId::get()),
+            Error::<Test>::InvalidChainId
+        );
+
+        assert_events(vec![Event::bridge(RawEvent::ChainWhitelisted(0))]);
+    })
+}
+
+#[test]
+fn set_get_threshold() {
+    new_test_ext().execute_with(|| {
+        assert_eq!(<RelayerThreshold>::get(), 1);
+
+        assert_ok!(Bridge::set_threshold(Origin::root(), TEST_THRESHOLD));
+        assert_eq!(<RelayerThreshold>::get(), TEST_THRESHOLD);
+
+        assert_ok!(Bridge::set_threshold(Origin::root(), 5));
+        assert_eq!(<RelayerThreshold>::get(), 5);
+
+        assert_events(vec![
+            Event::bridge(RawEvent::RelayerThresholdChanged(TEST_THRESHOLD)),
+            Event::bridge(RawEvent::RelayerThresholdChanged(5)),
+        ]);
+    })
+}
+
+#[test]
+fn asset_transfer_success() {
+    new_test_ext().execute_with(|| {
+        let dest_id = 2;
+        let to = vec![2];
+        let resource_id = [1; 32];
+        let metadata = vec![];
+        let amount = 100;
+        let token_id = vec![1, 2, 3, 4];
+
+        assert_ok!(Bridge::set_threshold(Origin::root(), TEST_THRESHOLD,));
+
+        assert_ok!(Bridge::whitelist_chain(Origin::root(), dest_id.clone()));
+        assert_ok!(Bridge::transfer_fungible(
+            dest_id.clone(),
+            resource_id.clone(),
+            to.clone(),
+            amount.into()
+        ));
+        assert_events(vec![
+            Event::bridge(RawEvent::ChainWhitelisted(dest_id.clone())),
+            Event::bridge(RawEvent::FungibleTransfer(
+                dest_id.clone(),
+                1,
+                resource_id.clone(),
+                amount.into(),
+                to.clone(),
+            )),
+        ]);
+
+        assert_ok!(Bridge::transfer_nonfungible(
+            dest_id.clone(),
+            resource_id.clone(),
+            token_id.clone(),
+            to.clone(),
+            metadata.clone()
+        ));
+        assert_events(vec![Event::bridge(RawEvent::NonFungibleTransfer(
+            dest_id.clone(),
+            2,
+            resource_id.clone(),
+            token_id,
+            to.clone(),
+            metadata.clone(),
+        ))]);
+
+        assert_ok!(Bridge::transfer_generic(
+            dest_id.clone(),
+            resource_id.clone(),
+            metadata.clone()
+        ));
+        assert_events(vec![Event::bridge(RawEvent::GenericTransfer(
+            dest_id.clone(),
+            3,
+            resource_id,
+            metadata,
+        ))]);
+    })
+}
+
+#[test]
+fn asset_transfer_invalid_chain() {
+    new_test_ext().execute_with(|| {
+        let chain_id = 2;
+        let bad_dest_id = 3;
+        let resource_id = [4; 32];
+
+        assert_ok!(Bridge::whitelist_chain(Origin::root(), chain_id.clone()));
+        assert_events(vec![Event::bridge(RawEvent::ChainWhitelisted(
+            chain_id.clone(),
+        ))]);
+
+        assert_noop!(
+            Bridge::transfer_fungible(bad_dest_id, resource_id.clone(), vec![], U256::zero()),
+            Error::<Test>::ChainNotWhitelisted
+        );
+
+        assert_noop!(
+            Bridge::transfer_nonfungible(bad_dest_id, resource_id.clone(), vec![], vec![], vec![]),
+            Error::<Test>::ChainNotWhitelisted
+        );
+
+        assert_noop!(
+            Bridge::transfer_generic(bad_dest_id, resource_id.clone(), vec![]),
+            Error::<Test>::ChainNotWhitelisted
+        );
+    })
+}
+
+#[test]
+fn add_remove_relayer() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Bridge::set_threshold(Origin::root(), TEST_THRESHOLD,));
+        assert_eq!(Bridge::relayer_count(), 0);
+
+        assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_A));
+        assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_B));
+        assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_C));
+        assert_eq!(Bridge::relayer_count(), 3);
+
+        // Already exists
+        assert_noop!(
+            Bridge::add_relayer(Origin::root(), RELAYER_A),
+            Error::<Test>::RelayerAlreadyExists
+        );
+
+        // Confirm removal
+        assert_ok!(Bridge::remove_relayer(Origin::root(), RELAYER_B));
+        assert_eq!(Bridge::relayer_count(), 2);
+        assert_noop!(
+            Bridge::remove_relayer(Origin::root(), RELAYER_B),
+            Error::<Test>::RelayerInvalid
+        );
+        assert_eq!(Bridge::relayer_count(), 2);
+
+        assert_events(vec![
+            Event::bridge(RawEvent::RelayerAdded(RELAYER_A)),
+            Event::bridge(RawEvent::RelayerAdded(RELAYER_B)),
+            Event::bridge(RawEvent::RelayerAdded(RELAYER_C)),
+            Event::bridge(RawEvent::RelayerRemoved(RELAYER_B)),
+        ]);
+    })
+}
+
+fn make_proposal(r: Vec<u8>) -> mock::Call {
+    Call::System(system::Call::remark(r))
+}
+
+#[test]
+fn create_sucessful_proposal() {
+    let src_id = 1;
+    let r_id = derive_resource_id(src_id, b"remark");
+
+    new_test_ext_initialized(src_id, r_id, b"System.remark".to_vec()).execute_with(|| {
+        let prop_id = 1;
+        let proposal = make_proposal(vec![10]);
+
+        // Create proposal (& vote)
+        assert_ok!(Bridge::acknowledge_proposal(
+            Origin::signed(RELAYER_A),
+            prop_id,
+            src_id,
+            r_id,
+            Box::new(proposal.clone())
+        ));
+        let prop = Bridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+        let expected = ProposalVotes {
+            votes_for: vec![RELAYER_A],
+            votes_against: vec![],
+            status: ProposalStatus::Initiated,
+            expiry: ProposalLifetime::get() + 1,
+        };
+        assert_eq!(prop, expected);
+
+        // Second relayer votes against
+        assert_ok!(Bridge::reject_proposal(
+            Origin::signed(RELAYER_B),
+            prop_id,
+            src_id,
+            r_id,
+            Box::new(proposal.clone())
+        ));
+        let prop = Bridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+        let expected = ProposalVotes {
+            votes_for: vec![RELAYER_A],
+            votes_against: vec![RELAYER_B],
+            status: ProposalStatus::Initiated,
+            expiry: ProposalLifetime::get() + 1,
+        };
+        assert_eq!(prop, expected);
+
+        // Third relayer votes in favour
+        assert_ok!(Bridge::acknowledge_proposal(
+            Origin::signed(RELAYER_C),
+            prop_id,
+            src_id,
+            r_id,
+            Box::new(proposal.clone())
+        ));
+        let prop = Bridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+        let expected = ProposalVotes {
+            votes_for: vec![RELAYER_A, RELAYER_C],
+            votes_against: vec![RELAYER_B],
+            status: ProposalStatus::Approved,
+            expiry: ProposalLifetime::get() + 1,
+        };
+        assert_eq!(prop, expected);
+
+        assert_events(vec![
+            Event::bridge(RawEvent::VoteFor(src_id, prop_id, RELAYER_A)),
+            Event::bridge(RawEvent::VoteAgainst(src_id, prop_id, RELAYER_B)),
+            Event::bridge(RawEvent::VoteFor(src_id, prop_id, RELAYER_C)),
+            Event::bridge(RawEvent::ProposalApproved(src_id, prop_id)),
+            Event::bridge(RawEvent::ProposalSucceeded(src_id, prop_id)),
+        ]);
+    })
+}
+
+#[test]
+fn create_unsucessful_proposal() {
+    let src_id = 1;
+    let r_id = derive_resource_id(src_id, b"transfer");
+
+    new_test_ext_initialized(src_id, r_id, b"System.remark".to_vec()).execute_with(|| {
+        let prop_id = 1;
+        let proposal = make_proposal(vec![11]);
+
+        // Create proposal (& vote)
+        assert_ok!(Bridge::acknowledge_proposal(
+            Origin::signed(RELAYER_A),
+            prop_id,
+            src_id,
+            r_id,
+            Box::new(proposal.clone())
+        ));
+        let prop = Bridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+        let expected = ProposalVotes {
+            votes_for: vec![RELAYER_A],
+            votes_against: vec![],
+            status: ProposalStatus::Initiated,
+            expiry: ProposalLifetime::get() + 1,
+        };
+        assert_eq!(prop, expected);
+
+        // Second relayer votes against
+        assert_ok!(Bridge::reject_proposal(
+            Origin::signed(RELAYER_B),
+            prop_id,
+            src_id,
+            r_id,
+            Box::new(proposal.clone())
+        ));
+        let prop = Bridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+        let expected = ProposalVotes {
+            votes_for: vec![RELAYER_A],
+            votes_against: vec![RELAYER_B],
+            status: ProposalStatus::Initiated,
+            expiry: ProposalLifetime::get() + 1,
+        };
+        assert_eq!(prop, expected);
+
+        // Third relayer votes against
+        assert_ok!(Bridge::reject_proposal(
+            Origin::signed(RELAYER_C),
+            prop_id,
+            src_id,
+            r_id,
+            Box::new(proposal.clone())
+        ));
+        let prop = Bridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+        let expected = ProposalVotes {
+            votes_for: vec![RELAYER_A],
+            votes_against: vec![RELAYER_B, RELAYER_C],
+            status: ProposalStatus::Rejected,
+            expiry: ProposalLifetime::get() + 1,
+        };
+        assert_eq!(prop, expected);
+
+        assert_eq!(Balances::free_balance(RELAYER_B), 0);
+        assert_eq!(
+            Balances::free_balance(Bridge::account_id()),
+            ENDOWED_BALANCE
+        );
+
+        assert_events(vec![
+            Event::bridge(RawEvent::VoteFor(src_id, prop_id, RELAYER_A)),
+            Event::bridge(RawEvent::VoteAgainst(src_id, prop_id, RELAYER_B)),
+            Event::bridge(RawEvent::VoteAgainst(src_id, prop_id, RELAYER_C)),
+            Event::bridge(RawEvent::ProposalRejected(src_id, prop_id)),
+        ]);
+    })
+}
+
+#[test]
+fn execute_after_threshold_change() {
+    let src_id = 1;
+    let r_id = derive_resource_id(src_id, b"transfer");
+
+    new_test_ext_initialized(src_id, r_id, b"System.remark".to_vec()).execute_with(|| {
+        let prop_id = 1;
+        let proposal = make_proposal(vec![11]);
+
+        // Create proposal (& vote)
+        assert_ok!(Bridge::acknowledge_proposal(
+            Origin::signed(RELAYER_A),
+            prop_id,
+            src_id,
+            r_id,
+            Box::new(proposal.clone())
+        ));
+        let prop = Bridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+        let expected = ProposalVotes {
+            votes_for: vec![RELAYER_A],
+            votes_against: vec![],
+            status: ProposalStatus::Initiated,
+            expiry: ProposalLifetime::get() + 1,
+        };
+        assert_eq!(prop, expected);
+
+        // Change threshold
+        assert_ok!(Bridge::set_threshold(Origin::root(), 1));
+
+        // Attempt to execute
+        assert_ok!(Bridge::eval_vote_state(
+            Origin::signed(RELAYER_A),
+            prop_id,
+            src_id,
+            Box::new(proposal.clone())
+        ));
+
+        let prop = Bridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+        let expected = ProposalVotes {
+            votes_for: vec![RELAYER_A],
+            votes_against: vec![],
+            status: ProposalStatus::Approved,
+            expiry: ProposalLifetime::get() + 1,
+        };
+        assert_eq!(prop, expected);
+
+        assert_eq!(Balances::free_balance(RELAYER_B), 0);
+        assert_eq!(
+            Balances::free_balance(Bridge::account_id()),
+            ENDOWED_BALANCE
+        );
+
+        assert_events(vec![
+            Event::bridge(RawEvent::VoteFor(src_id, prop_id, RELAYER_A)),
+            Event::bridge(RawEvent::RelayerThresholdChanged(1)),
+            Event::bridge(RawEvent::ProposalApproved(src_id, prop_id)),
+            Event::bridge(RawEvent::ProposalSucceeded(src_id, prop_id)),
+        ]);
+    })
+}
+
+#[test]
+fn proposal_expires() {
+    let src_id = 1;
+    let r_id = derive_resource_id(src_id, b"remark");
+
+    new_test_ext_initialized(src_id, r_id, b"System.remark".to_vec()).execute_with(|| {
+        let prop_id = 1;
+        let proposal = make_proposal(vec![10]);
+
+        // Create proposal (& vote)
+        assert_ok!(Bridge::acknowledge_proposal(
+            Origin::signed(RELAYER_A),
+            prop_id,
+            src_id,
+            r_id,
+            Box::new(proposal.clone())
+        ));
+        let prop = Bridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+        let expected = ProposalVotes {
+            votes_for: vec![RELAYER_A],
+            votes_against: vec![],
+            status: ProposalStatus::Initiated,
+            expiry: ProposalLifetime::get() + 1,
+        };
+        assert_eq!(prop, expected);
+
+        // Increment enough blocks such that now == expiry
+        System::set_block_number(ProposalLifetime::get() + 1);
+
+        // Attempt to submit a vote should fail
+        assert_noop!(
+            Bridge::reject_proposal(
+                Origin::signed(RELAYER_B),
+                prop_id,
+                src_id,
+                r_id,
+                Box::new(proposal.clone())
+            ),
+            Error::<Test>::ProposalExpired
+        );
+
+        // Proposal state should remain unchanged
+        let prop = Bridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+        let expected = ProposalVotes {
+            votes_for: vec![RELAYER_A],
+            votes_against: vec![],
+            status: ProposalStatus::Initiated,
+            expiry: ProposalLifetime::get() + 1,
+        };
+        assert_eq!(prop, expected);
+
+        // eval_vote_state should have no effect
+        assert_noop!(
+            Bridge::eval_vote_state(
+                Origin::signed(RELAYER_C),
+                prop_id,
+                src_id,
+                Box::new(proposal.clone())
+            ),
+            Error::<Test>::ProposalExpired
+        );
+        let prop = Bridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+        let expected = ProposalVotes {
+            votes_for: vec![RELAYER_A],
+            votes_against: vec![],
+            status: ProposalStatus::Initiated,
+            expiry: ProposalLifetime::get() + 1,
+        };
+        assert_eq!(prop, expected);
+
+        assert_events(vec![Event::bridge(RawEvent::VoteFor(
+            src_id, prop_id, RELAYER_A,
+        ))]);
+    })
+}

--- a/frame/erc20/Cargo.toml
+++ b/frame/erc20/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "pallet-erc20"
+version = "2.0.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+license = "Unlicense"
+homepage = "https://substrate.dev"
+repository = "https://github.com/paritytech/substrate/"
+description = "FRAME example pallet"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+serde = { version = "1.0.101", optional = true }
+codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false }
+frame-support = { version = "2.0.0", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0", default-features = false, path = "../system" }
+pallet-balances = { version = "2.0.0", default-features = false, path = "../balances" }
+sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
+sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/io" }
+sp-core = { version = "2.0.0", path = "../../primitives/core", default-features = false }
+sp-arithmetic = { version = "2.0.0", path = "../../primitives/arithmetic", default-features = false }
+pallet-chainbridge = { version = "2.0.0", default-features = false, path = "../chainbridge" }
+pallet-erc721 = { version = "2.0.0", default-features = false, path = "../erc721" }
+
+frame-benchmarking = { version = "2.0.0", default-features = false, path = "../benchmarking", optional = true }
+
+[features]
+default = ["std"]
+std = [
+	"serde",
+	"codec/std",
+	"sp-runtime/std",
+	"frame-benchmarking/std",
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-balances/std",
+	"sp-io/std",
+	"sp-std/std",
+	"sp-core/std",
+	"sp-arithmetic/std",
+	"pallet-chainbridge/std",
+	"pallet-erc721/std"
+]
+runtime-benchmarks = ["frame-benchmarking"]

--- a/frame/erc20/src/lib.rs
+++ b/frame/erc20/src/lib.rs
@@ -1,0 +1,144 @@
+// Ensure we're `no_std` when compiling for Wasm.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use pallet_chainbridge as bridge;
+use pallet_erc721 as erc721;
+
+use sp_std::marker::PhantomData;
+use frame_support::{
+	dispatch::{DispatchResult, IsSubType}, decl_module, decl_storage, decl_event, decl_error,
+	traits::{Currency, EnsureOrigin, ExistenceRequirement::AllowDeath, Get},
+	ensure,
+	weights::{DispatchClass, ClassifyDispatch, WeighData, Weight, PaysFee, Pays},
+};
+use sp_std::prelude::*;
+use frame_system::{self as system, ensure_signed, ensure_root};
+use sp_arithmetic::traits::SaturatedConversion;
+use sp_core::U256;
+use codec::{Encode, Decode};
+use sp_runtime::{
+	traits::{
+		SignedExtension, Bounded, DispatchInfoOf, UniqueSaturatedInto,
+	},
+	transaction_validity::{
+		ValidTransaction, TransactionValidityError, InvalidTransaction, TransactionValidity,
+	},
+};
+
+type ResourceId = bridge::ResourceId;
+
+type BalanceOf<T> =
+    <<T as Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
+
+pub trait Trait: system::Trait + bridge::Trait + erc721::Trait {
+    type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
+    /// Specifies the origin check provided by the bridge for calls that can only be called by the bridge pallet
+    type BridgeOrigin: EnsureOrigin<Self::Origin, Success = Self::AccountId>;
+
+    /// The currency mechanism.
+    type Currency: Currency<Self::AccountId>;
+
+    /// Ids can be defined by the runtime and passed in, perhaps from blake2b_128 hashes.
+    type HashId: Get<ResourceId>;
+    type NativeTokenId: Get<ResourceId>;
+    type Erc721Id: Get<ResourceId>;
+}
+
+decl_error! {
+    pub enum Error for Module<T: Trait>{
+        InvalidTransfer,
+    }
+}
+
+decl_event!(
+    pub enum Event<T> where
+        <T as frame_system::Trait>::Hash,
+    {
+        Remark(Hash),
+    }
+);
+
+decl_module! {
+    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        const HashId: ResourceId = T::HashId::get();
+        const NativeTokenId: ResourceId = T::NativeTokenId::get();
+        const Erc721Id: ResourceId = T::Erc721Id::get();
+
+        fn deposit_event() = default;
+
+        //
+        // Initiation calls. These start a bridge transfer.
+        //
+
+        /// Transfers an arbitrary hash to a (whitelisted) destination chain.
+        #[weight = 195_000_000]
+        pub fn transfer_hash(origin, hash: T::Hash, dest_id: bridge::ChainId) -> DispatchResult {
+            ensure_signed(origin)?;
+
+            let resource_id = T::HashId::get();
+            let metadata: Vec<u8> = hash.as_ref().to_vec();
+            <bridge::Module<T>>::transfer_generic(dest_id, resource_id, metadata)
+        }
+
+        /// Transfers some amount of the native token to some recipient on a (whitelisted) destination chain.
+        #[weight = 195_000_000]
+        pub fn transfer_native(origin, amount: BalanceOf<T>, recipient: Vec<u8>, dest_id: bridge::ChainId) -> DispatchResult {
+            let source = ensure_signed(origin)?;
+            ensure!(<bridge::Module<T>>::chain_whitelisted(dest_id), Error::<T>::InvalidTransfer);
+            let bridge_id = <bridge::Module<T>>::account_id();
+            T::Currency::transfer(&source, &bridge_id, amount.into(), AllowDeath)?;
+
+            let resource_id = T::NativeTokenId::get();
+			let number_amount: u128 = amount.saturated_into();
+
+			// <bridge::Module<T>>::transfer_fungible(dest_id, resource_id, recipient, U256::from(amount.saturated_into()))
+            <bridge::Module<T>>::transfer_fungible(dest_id, resource_id, recipient, U256::from(number_amount))
+			// <bridge::Module<T>>::transfer_fungible(dest_id, resource_id, recipient, U256::from(UniqueSaturatedInto::<u128>::unique_saturated_into(amount)))
+        }
+
+        /// Transfer a non-fungible token (erc721) to a (whitelisted) destination chain.
+        #[weight = 195_000_000]
+        pub fn transfer_erc721(origin, recipient: Vec<u8>, token_id: U256, dest_id: bridge::ChainId) -> DispatchResult {
+            let source = ensure_signed(origin)?;
+            ensure!(<bridge::Module<T>>::chain_whitelisted(dest_id), Error::<T>::InvalidTransfer);
+            match <erc721::Module<T>>::tokens(&token_id) {
+                Some(token) => {
+                    <erc721::Module<T>>::burn_token(source, token_id)?;
+                    let resource_id = T::Erc721Id::get();
+                    let tid: &mut [u8] = &mut[0; 32];
+                    token_id.to_big_endian(tid);
+                    <bridge::Module<T>>::transfer_nonfungible(dest_id, resource_id, tid.to_vec(), recipient, token.metadata)
+                }
+                None => Err(Error::<T>::InvalidTransfer)?
+            }
+        }
+
+        //
+        // Executable calls. These can be triggered by a bridge transfer initiated on another chain
+        //
+
+        /// Executes a simple currency transfer using the bridge account as the source
+        #[weight = 195_000_000]
+        pub fn transfer(origin, to: T::AccountId, amount: BalanceOf<T>) -> DispatchResult {
+            let source = T::BridgeOrigin::ensure_origin(origin)?;
+            <T as Trait>::Currency::transfer(&source, &to, amount.into(), AllowDeath)?;
+            Ok(())
+        }
+
+        /// This can be called by the bridge to demonstrate an arbitrary call from a proposal.
+        #[weight = 195_000_000]
+        pub fn remark(origin, hash: T::Hash) -> DispatchResult {
+            T::BridgeOrigin::ensure_origin(origin)?;
+            Self::deposit_event(RawEvent::Remark(hash));
+            Ok(())
+        }
+
+        /// Allows the bridge to issue new erc721 tokens
+        #[weight = 195_000_000]
+        pub fn mint_erc721(origin, recipient: T::AccountId, id: U256, metadata: Vec<u8>) -> DispatchResult {
+            T::BridgeOrigin::ensure_origin(origin)?;
+            <erc721::Module<T>>::mint_token(recipient, id, metadata)?;
+            Ok(())
+        }
+    }
+}

--- a/frame/erc20/src/mock.rs
+++ b/frame/erc20/src/mock.rs
@@ -1,0 +1,183 @@
+#![cfg(test)]
+
+use super::*;
+
+use frame_support::{ord_parameter_types, parameter_types, weights::Weight};
+use frame_system::{self as system};
+use sp_core::hashing::blake2_128;
+use sp_core::H256;
+use sp_runtime::{
+    testing::Header,
+    traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, IdentityLookup},
+    ModuleId, Perbill,
+};
+
+use crate::{self as example, Trait};
+use chainbridge as bridge;
+pub use pallet_balances as balances;
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: Weight = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+
+impl frame_system::Trait for Test {
+    type BaseCallFilter = ();
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = BlockHashCount;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type DbWeight = ();
+    type BlockExecutionWeight = ();
+    type ExtrinsicBaseWeight = ();
+    type MaximumExtrinsicWeight = ();
+    type MaximumBlockLength = MaximumBlockLength;
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type Version = ();
+    type ModuleToIndex = ();
+    type AccountData = balances::AccountData<u64>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+}
+
+parameter_types! {
+    pub const ExistentialDeposit: u64 = 1;
+}
+
+ord_parameter_types! {
+    pub const One: u64 = 1;
+}
+
+impl pallet_balances::Trait for Test {
+    type Balance = u64;
+    type DustRemoval = ();
+    type Event = Event;
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    pub const TestChainId: u8 = 5;
+    pub const ProposalLifetime: u64 = 100;
+}
+
+impl bridge::Trait for Test {
+    type Event = Event;
+    type AdminOrigin = frame_system::EnsureRoot<Self::AccountId>;
+    type Proposal = Call;
+    type ChainId = TestChainId;
+    type ProposalLifetime = ProposalLifetime;
+}
+
+parameter_types! {
+    pub HashId: bridge::ResourceId = bridge::derive_resource_id(1, &blake2_128(b"hash"));
+    pub NativeTokenId: bridge::ResourceId = bridge::derive_resource_id(1, &blake2_128(b"DAV"));
+    pub Erc721Id: bridge::ResourceId = bridge::derive_resource_id(1, &blake2_128(b"NFT"));
+}
+
+impl erc721::Trait for Test {
+    type Event = Event;
+    type Identifier = Erc721Id;
+}
+
+impl Trait for Test {
+    type Event = Event;
+    type BridgeOrigin = bridge::EnsureBridge<Test>;
+    type Currency = Balances;
+    type HashId = HashId;
+    type NativeTokenId = NativeTokenId;
+    type Erc721Id = Erc721Id;
+}
+
+pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
+pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, u64, Call, ()>;
+
+frame_support::construct_runtime!(
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic
+    {
+        System: system::{Module, Call, Event<T>},
+        Balances: balances::{Module, Call, Storage, Config<T>, Event<T>},
+        Bridge: bridge::{Module, Call, Storage, Event<T>},
+        Erc721: erc721::{Module, Call, Storage, Event<T>},
+        Example: example::{Module, Call, Event<T>}
+    }
+);
+
+pub const RELAYER_A: u64 = 0x2;
+pub const RELAYER_B: u64 = 0x3;
+pub const RELAYER_C: u64 = 0x4;
+pub const ENDOWED_BALANCE: u64 = 100_000_000;
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    let bridge_id = ModuleId(*b"cb/bridg").into_account();
+    let mut t = frame_system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
+    pallet_balances::GenesisConfig::<Test> {
+        balances: vec![(bridge_id, ENDOWED_BALANCE), (RELAYER_A, ENDOWED_BALANCE)],
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+    let mut ext = sp_io::TestExternalities::new(t);
+    ext.execute_with(|| System::set_block_number(1));
+    ext
+}
+
+fn last_event() -> Event {
+    system::Module::<Test>::events()
+        .pop()
+        .map(|e| e.event)
+        .expect("Event expected")
+}
+
+pub fn expect_event<E: Into<Event>>(e: E) {
+    assert_eq!(last_event(), e.into());
+}
+
+// Asserts that the event was emitted at some point.
+pub fn event_exists<E: Into<Event>>(e: E) {
+    let actual: Vec<Event> = system::Module::<Test>::events()
+        .iter()
+        .map(|e| e.event.clone())
+        .collect();
+    let e: Event = e.into();
+    let mut exists = false;
+    for evt in actual {
+        if evt == e {
+            exists = true;
+            break;
+        }
+    }
+    assert!(exists);
+}
+
+// Checks events against the latest. A contiguous set of events must be provided. They must
+// include the most recent event, but do not have to include every past event.
+pub fn assert_events(mut expected: Vec<Event>) {
+    let mut actual: Vec<Event> = system::Module::<Test>::events()
+        .iter()
+        .map(|e| e.event.clone())
+        .collect();
+
+    expected.reverse();
+
+    for evt in expected {
+        let next = actual.pop().expect("event expected");
+        assert_eq!(next, evt.into(), "Events don't match");
+    }
+}

--- a/frame/erc20/src/tests.rs
+++ b/frame/erc20/src/tests.rs
@@ -1,0 +1,338 @@
+#![cfg(test)]
+
+use super::mock::{
+    assert_events, balances, event_exists, expect_event, new_test_ext, Balances, Bridge, Call,
+    Erc721, Erc721Id, Event, Example, HashId, NativeTokenId, Origin, ProposalLifetime, Test,
+    ENDOWED_BALANCE, RELAYER_A, RELAYER_B, RELAYER_C,
+};
+use super::*;
+use frame_support::dispatch::DispatchError;
+use frame_support::{assert_noop, assert_ok};
+
+use codec::Encode;
+use example_erc721::Erc721Token;
+use sp_core::{blake2_256, H256};
+
+const TEST_THRESHOLD: u32 = 2;
+
+fn make_remark_proposal(hash: H256) -> Call {
+    Call::Example(crate::Call::remark(hash))
+}
+
+fn make_transfer_proposal(to: u64, amount: u64) -> Call {
+    Call::Example(crate::Call::transfer(to, amount.into()))
+}
+
+#[test]
+fn transfer_hash() {
+    new_test_ext().execute_with(|| {
+        let dest_chain = 0;
+        let resource_id = HashId::get();
+        let hash: H256 = "ABC".using_encoded(blake2_256).into();
+
+        assert_ok!(Bridge::set_threshold(Origin::root(), TEST_THRESHOLD,));
+
+        assert_ok!(Bridge::whitelist_chain(Origin::root(), dest_chain.clone()));
+        assert_ok!(Example::transfer_hash(
+            Origin::signed(1),
+            hash.clone(),
+            dest_chain,
+        ));
+
+        expect_event(bridge::RawEvent::GenericTransfer(
+            dest_chain,
+            1,
+            resource_id,
+            hash.as_ref().to_vec(),
+        ));
+    })
+}
+
+#[test]
+fn transfer_native() {
+    new_test_ext().execute_with(|| {
+        let dest_chain = 0;
+        let resource_id = NativeTokenId::get();
+        let amount: u64 = 100;
+        let recipient = vec![99];
+
+        assert_ok!(Bridge::whitelist_chain(Origin::root(), dest_chain.clone()));
+        assert_ok!(Example::transfer_native(
+            Origin::signed(RELAYER_A),
+            amount.clone(),
+            recipient.clone(),
+            dest_chain,
+        ));
+
+        expect_event(bridge::RawEvent::FungibleTransfer(
+            dest_chain,
+            1,
+            resource_id,
+            amount.into(),
+            recipient,
+        ));
+    })
+}
+
+#[test]
+fn transfer_erc721() {
+    new_test_ext().execute_with(|| {
+        let dest_chain = 0;
+        let resource_id = Erc721Id::get();
+        let token_id: U256 = U256::from(100);
+        let token_id_slice: &mut [u8] = &mut [0; 32];
+        token_id.to_big_endian(token_id_slice);
+        let metadata: Vec<u8> = vec![1, 2, 3, 4];
+        let recipient = vec![99];
+
+        // Create a token
+        assert_ok!(Erc721::mint(
+            Origin::root(),
+            RELAYER_A,
+            token_id,
+            metadata.clone()
+        ));
+        assert_eq!(
+            Erc721::tokens(token_id).unwrap(),
+            Erc721Token {
+                id: token_id,
+                metadata: metadata.clone()
+            }
+        );
+
+        // Whitelist destination and transfer
+        assert_ok!(Bridge::whitelist_chain(Origin::root(), dest_chain.clone()));
+        assert_ok!(Example::transfer_erc721(
+            Origin::signed(RELAYER_A),
+            recipient.clone(),
+            token_id,
+            dest_chain,
+        ));
+
+        expect_event(bridge::RawEvent::NonFungibleTransfer(
+            dest_chain,
+            1,
+            resource_id,
+            token_id_slice.to_vec(),
+            recipient.clone(),
+            metadata,
+        ));
+
+        // Ensure token no longer exists
+        assert_eq!(Erc721::tokens(token_id), None);
+
+        // Transfer should fail as token doesn't exist
+        assert_noop!(
+            Example::transfer_erc721(
+                Origin::signed(RELAYER_A),
+                recipient.clone(),
+                token_id,
+                dest_chain,
+            ),
+            Error::<Test>::InvalidTransfer
+        );
+    })
+}
+
+#[test]
+fn execute_remark() {
+    new_test_ext().execute_with(|| {
+        let hash: H256 = "ABC".using_encoded(blake2_256).into();
+        let proposal = make_remark_proposal(hash.clone());
+        let prop_id = 1;
+        let src_id = 1;
+        let r_id = bridge::derive_resource_id(src_id, b"hash");
+        let resource = b"Example.remark".to_vec();
+
+        assert_ok!(Bridge::set_threshold(Origin::root(), TEST_THRESHOLD,));
+        assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_A));
+        assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_B));
+        assert_ok!(Bridge::whitelist_chain(Origin::root(), src_id));
+        assert_ok!(Bridge::set_resource(Origin::root(), r_id, resource));
+
+        assert_ok!(Bridge::acknowledge_proposal(
+            Origin::signed(RELAYER_A),
+            prop_id,
+            src_id,
+            r_id,
+            Box::new(proposal.clone())
+        ));
+        assert_ok!(Bridge::acknowledge_proposal(
+            Origin::signed(RELAYER_B),
+            prop_id,
+            src_id,
+            r_id,
+            Box::new(proposal.clone())
+        ));
+
+        event_exists(RawEvent::Remark(hash));
+    })
+}
+
+#[test]
+fn execute_remark_bad_origin() {
+    new_test_ext().execute_with(|| {
+        let hash: H256 = "ABC".using_encoded(blake2_256).into();
+
+        assert_ok!(Example::remark(Origin::signed(Bridge::account_id()), hash));
+        // Don't allow any signed origin except from bridge addr
+        assert_noop!(
+            Example::remark(Origin::signed(RELAYER_A), hash),
+            DispatchError::BadOrigin
+        );
+        // Don't allow root calls
+        assert_noop!(
+            Example::remark(Origin::root(), hash),
+            DispatchError::BadOrigin
+        );
+    })
+}
+
+#[test]
+fn transfer() {
+    new_test_ext().execute_with(|| {
+        // Check inital state
+        let bridge_id: u64 = Bridge::account_id();
+        assert_eq!(Balances::free_balance(&bridge_id), ENDOWED_BALANCE);
+        // Transfer and check result
+        assert_ok!(Example::transfer(
+            Origin::signed(Bridge::account_id()),
+            RELAYER_A,
+            10
+        ));
+        assert_eq!(Balances::free_balance(&bridge_id), ENDOWED_BALANCE - 10);
+        assert_eq!(Balances::free_balance(RELAYER_A), ENDOWED_BALANCE + 10);
+
+        assert_events(vec![Event::balances(balances::RawEvent::Transfer(
+            Bridge::account_id(),
+            RELAYER_A,
+            10,
+        ))]);
+    })
+}
+
+#[test]
+fn mint_erc721() {
+    new_test_ext().execute_with(|| {
+        let token_id = U256::from(99);
+        let recipient = RELAYER_A;
+        let metadata = vec![1, 1, 1, 1];
+        let bridge_id: u64 = Bridge::account_id();
+
+        // Token doesn't yet exist
+        assert_eq!(Erc721::tokens(token_id), None);
+        // Mint
+        assert_ok!(Example::mint_erc721(
+            Origin::signed(bridge_id),
+            recipient,
+            token_id,
+            metadata.clone()
+        ));
+        // Ensure token exists
+        assert_eq!(
+            Erc721::tokens(token_id).unwrap(),
+            Erc721Token {
+                id: token_id,
+                metadata: metadata.clone()
+            }
+        );
+        // Cannot mint same token
+        assert_noop!(
+            Example::mint_erc721(
+                Origin::signed(bridge_id),
+                recipient,
+                token_id,
+                metadata.clone()
+            ),
+            erc721::Error::<Test>::TokenAlreadyExists
+        );
+    })
+}
+
+#[test]
+fn create_sucessful_transfer_proposal() {
+    new_test_ext().execute_with(|| {
+        let prop_id = 1;
+        let src_id = 1;
+        let r_id = bridge::derive_resource_id(src_id, b"transfer");
+        let resource = b"Example.transfer".to_vec();
+        let proposal = make_transfer_proposal(RELAYER_A, 10);
+
+        assert_ok!(Bridge::set_threshold(Origin::root(), TEST_THRESHOLD,));
+        assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_A));
+        assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_B));
+        assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_C));
+        assert_ok!(Bridge::whitelist_chain(Origin::root(), src_id));
+        assert_ok!(Bridge::set_resource(Origin::root(), r_id, resource));
+
+        // Create proposal (& vote)
+        assert_ok!(Bridge::acknowledge_proposal(
+            Origin::signed(RELAYER_A),
+            prop_id,
+            src_id,
+            r_id,
+            Box::new(proposal.clone())
+        ));
+        let prop = Bridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+        let expected = bridge::ProposalVotes {
+            votes_for: vec![RELAYER_A],
+            votes_against: vec![],
+            status: bridge::ProposalStatus::Initiated,
+            expiry: ProposalLifetime::get() + 1,
+        };
+        assert_eq!(prop, expected);
+
+        // Second relayer votes against
+        assert_ok!(Bridge::reject_proposal(
+            Origin::signed(RELAYER_B),
+            prop_id,
+            src_id,
+            r_id,
+            Box::new(proposal.clone())
+        ));
+        let prop = Bridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+        let expected = bridge::ProposalVotes {
+            votes_for: vec![RELAYER_A],
+            votes_against: vec![RELAYER_B],
+            status: bridge::ProposalStatus::Initiated,
+            expiry: ProposalLifetime::get() + 1,
+        };
+        assert_eq!(prop, expected);
+
+        // Third relayer votes in favour
+        assert_ok!(Bridge::acknowledge_proposal(
+            Origin::signed(RELAYER_C),
+            prop_id,
+            src_id,
+            r_id,
+            Box::new(proposal.clone())
+        ));
+        let prop = Bridge::votes(src_id, (prop_id.clone(), proposal.clone())).unwrap();
+        let expected = bridge::ProposalVotes {
+            votes_for: vec![RELAYER_A, RELAYER_C],
+            votes_against: vec![RELAYER_B],
+            status: bridge::ProposalStatus::Approved,
+            expiry: ProposalLifetime::get() + 1,
+        };
+        assert_eq!(prop, expected);
+
+        assert_eq!(Balances::free_balance(RELAYER_A), ENDOWED_BALANCE + 10);
+        assert_eq!(
+            Balances::free_balance(Bridge::account_id()),
+            ENDOWED_BALANCE - 10
+        );
+
+        assert_events(vec![
+            Event::bridge(bridge::RawEvent::VoteFor(src_id, prop_id, RELAYER_A)),
+            Event::bridge(bridge::RawEvent::VoteAgainst(src_id, prop_id, RELAYER_B)),
+            Event::bridge(bridge::RawEvent::VoteFor(src_id, prop_id, RELAYER_C)),
+            Event::bridge(bridge::RawEvent::ProposalApproved(src_id, prop_id)),
+            Event::balances(balances::RawEvent::Transfer(
+                Bridge::account_id(),
+                RELAYER_A,
+                10,
+            )),
+            Event::bridge(bridge::RawEvent::ProposalSucceeded(src_id, prop_id)),
+        ]);
+    })
+}

--- a/frame/erc721/Cargo.toml
+++ b/frame/erc721/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "pallet-erc721"
+version = "2.0.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+license = "Unlicense"
+homepage = "https://substrate.dev"
+repository = "https://github.com/paritytech/substrate/"
+description = "FRAME example pallet"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+serde = { version = "1.0.101", optional = true }
+codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false }
+frame-support = { version = "2.0.0", default-features = false, path = "../support" }
+frame-system = { version = "2.0.0", default-features = false, path = "../system" }
+pallet-balances = { version = "2.0.0", default-features = false, path = "../balances" }
+sp-runtime = { version = "2.0.0", default-features = false, path = "../../primitives/runtime" }
+sp-std = { version = "2.0.0", default-features = false, path = "../../primitives/std" }
+sp-io = { version = "2.0.0", default-features = false, path = "../../primitives/io" }
+sp-core = { version = "2.0.0", path = "../../primitives/core", default-features = false }
+pallet-chainbridge = { version = "2.0.0", default-features = false, path = "../chainbridge" }
+
+frame-benchmarking = { version = "2.0.0", default-features = false, path = "../benchmarking", optional = true }
+
+[features]
+default = ["std"]
+std = [
+	"serde",
+	"codec/std",
+	"sp-runtime/std",
+	"frame-benchmarking/std",
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-balances/std",
+	"sp-io/std",
+	"sp-std/std",
+	"sp-core/std",
+	"pallet-chainbridge/std"
+]
+runtime-benchmarks = ["frame-benchmarking"]

--- a/frame/erc721/src/lib.rs
+++ b/frame/erc721/src/lib.rs
@@ -1,0 +1,163 @@
+// Ensure we're `no_std` when compiling for Wasm.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use sp_std::marker::PhantomData;
+use frame_support::{
+	dispatch::{DispatchResult, IsSubType}, decl_module, decl_storage, decl_event, decl_error,
+	ensure,
+	traits::Get,
+	weights::{DispatchClass, ClassifyDispatch, WeighData, Weight, PaysFee, Pays},
+};
+use sp_std::prelude::*;
+use frame_system::{self as system, ensure_signed, ensure_root};
+use sp_core::U256;
+use codec::{Encode, Decode};
+use sp_runtime::{
+	traits::{
+		SignedExtension, Bounded, SaturatedConversion, DispatchInfoOf,
+	},
+	transaction_validity::{
+		ValidTransaction, TransactionValidityError, InvalidTransaction, TransactionValidity,
+	},
+	RuntimeDebug,
+};
+
+mod mock;
+mod tests;
+
+type TokenId = U256;
+
+#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
+pub struct Erc721Token {
+    pub id: TokenId,
+    pub metadata: Vec<u8>,
+}
+
+pub trait Trait: system::Trait {
+    type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
+
+    /// Some identifier for this token type, possibly the originating ethereum address.
+    /// This is not explicitly used for anything, but may reflect the bridge's notion of resource ID.
+    type Identifier: Get<[u8; 32]>;
+}
+
+decl_error! {
+    pub enum Error for Module<T: Trait> {
+        /// ID not recognized
+        TokenIdDoesNotExist,
+        /// Already exists with an owner
+        TokenAlreadyExists,
+        /// Origin is not owner
+        NotOwner,
+    }
+}
+
+decl_storage! {
+	trait Store for Module<T: Trait> as TokenStorage {
+        /// Maps tokenId to Erc721 object
+        Tokens get(fn tokens): map hasher(opaque_blake2_256) TokenId => Option<Erc721Token>;
+        /// Maps tokenId to owner
+        TokenOwner get(fn owner_of): map hasher(opaque_blake2_256) TokenId => Option<T::AccountId>;
+        /// Total number of tokens in existence
+        TokenCount get(fn token_count): U256 = U256::zero();
+    }
+}
+
+decl_event!(
+	pub enum Event<T>
+    where
+        <T as system::Trait>::AccountId,
+    {
+        /// New token created
+        Minted(AccountId, TokenId),
+        /// Token transfer between two parties
+        Transferred(AccountId, AccountId, TokenId),
+        /// Token removed from the system
+        Burned(TokenId),
+    }
+);
+
+decl_module! {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        type Error = Error<T>;
+        fn deposit_event() = default;
+
+        /// Creates a new token with the given token ID and metadata, and gives ownership to owner
+        #[weight = 195_000_000]
+        pub fn mint(origin, owner: T::AccountId, id: TokenId, metadata: Vec<u8>) -> DispatchResult {
+            ensure_root(origin)?;
+
+            Self::mint_token(owner, id, metadata)?;
+
+            Ok(())
+        }
+
+        /// Changes ownership of a token sender owns
+        #[weight = 195_000_000]
+        pub fn transfer(origin, to: T::AccountId, id: TokenId) -> DispatchResult {
+            let sender = ensure_signed(origin)?;
+
+            Self::transfer_from(sender, to, id)?;
+
+            Ok(())
+        }
+
+        /// Remove token from the system
+        #[weight = 195_000_000]
+        pub fn burn(origin, id: TokenId) -> DispatchResult {
+            ensure_root(origin)?;
+
+            let owner = Self::owner_of(id).ok_or(Error::<T>::TokenIdDoesNotExist)?;
+
+            Self::burn_token(owner, id)?;
+
+            Ok(())
+        }
+    }
+}
+
+impl<T: Trait> Module<T> {
+    /// Creates a new token in the system.
+    pub fn mint_token(owner: T::AccountId, id: TokenId, metadata: Vec<u8>) -> DispatchResult {
+        ensure!(!Tokens::contains_key(id), Error::<T>::TokenAlreadyExists);
+
+        let new_token = Erc721Token { id, metadata };
+
+        <Tokens>::insert(&id, new_token);
+        <TokenOwner<T>>::insert(&id, owner.clone());
+        let new_total = <TokenCount>::get().saturating_add(U256::one());
+        <TokenCount>::put(new_total);
+
+        Self::deposit_event(RawEvent::Minted(owner, id));
+
+        Ok(())
+    }
+
+    /// Modifies ownership of a token
+    pub fn transfer_from(from: T::AccountId, to: T::AccountId, id: TokenId) -> DispatchResult {
+        // Check from is owner and token exists
+        let owner = Self::owner_of(id).ok_or(Error::<T>::TokenIdDoesNotExist)?;
+        ensure!(owner == from, Error::<T>::NotOwner);
+        // Update owner
+        <TokenOwner<T>>::insert(&id, to.clone());
+
+        Self::deposit_event(RawEvent::Transferred(from, to, id));
+
+        Ok(())
+    }
+
+    /// Deletes a token from the system.
+    pub fn burn_token(from: T::AccountId, id: TokenId) -> DispatchResult {
+        let owner = Self::owner_of(id).ok_or(Error::<T>::TokenIdDoesNotExist)?;
+        ensure!(owner == from, Error::<T>::NotOwner);
+
+        <Tokens>::remove(&id);
+        <TokenOwner<T>>::remove(&id);
+        let new_total = <TokenCount>::get().saturating_sub(U256::one());
+        <TokenCount>::put(new_total);
+
+        Self::deposit_event(RawEvent::Burned(id));
+
+        Ok(())
+    }
+}

--- a/frame/erc721/src/mock.rs
+++ b/frame/erc721/src/mock.rs
@@ -1,0 +1,108 @@
+#![cfg(test)]
+
+use frame_support::{ord_parameter_types, parameter_types, weights::Weight};
+use frame_system::{self as system};
+use sp_core::hashing::blake2_128;
+use sp_core::H256;
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, Block as BlockT, IdentityLookup},
+    BuildStorage, Perbill,
+};
+
+use crate::{self as erc721, Trait};
+use pallet_chainbridge as bridge;
+pub use pallet_balances as balances;
+
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: Weight = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+
+impl frame_system::Trait for Test {
+    type BaseCallFilter = ();
+    type Origin = Origin;
+    type Call = Call;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = Event;
+    type BlockHashCount = BlockHashCount;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type DbWeight = ();
+    type BlockExecutionWeight = ();
+    type ExtrinsicBaseWeight = ();
+    type MaximumExtrinsicWeight = ();
+    type MaximumBlockLength = MaximumBlockLength;
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type Version = ();
+    type PalletInfo = ();
+    type AccountData = balances::AccountData<u64>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+}
+
+parameter_types! {
+    pub const ExistentialDeposit: u64 = 1;
+}
+
+ord_parameter_types! {
+    pub const One: u64 = 1;
+}
+
+impl pallet_balances::Trait for Test {
+    type Balance = u64;
+    type DustRemoval = ();
+    type Event = Event;
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type WeightInfo = ();
+    type MaxLocks = ();
+}
+
+parameter_types! {
+    pub Erc721Id: bridge::ResourceId = bridge::derive_resource_id(1, &blake2_128(b"NFT"));
+}
+
+impl Trait for Test {
+    type Event = Event;
+    type Identifier = Erc721Id;
+}
+
+pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
+pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, u64, Call, ()>;
+
+frame_support::construct_runtime!(
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic
+    {
+        System: system::{Module, Call, Event<T>},
+        Balances: balances::{Module, Call, Storage, Config<T>, Event<T>},
+        Erc721: erc721::{Module, Call, Storage, Event<T>},
+    }
+);
+
+pub const USER_A: u64 = 0x1;
+pub const USER_B: u64 = 0x2;
+pub const USER_C: u64 = 0x3;
+pub const ENDOWED_BALANCE: u64 = 100_000_000;
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    GenesisConfig {
+        balances: Some(balances::GenesisConfig {
+            balances: vec![(USER_A, ENDOWED_BALANCE)],
+        }),
+    }
+    .build_storage()
+    .unwrap()
+    .into()
+}

--- a/frame/erc721/src/tests.rs
+++ b/frame/erc721/src/tests.rs
@@ -1,0 +1,99 @@
+#![cfg(test)]
+
+use super::mock::{new_test_ext, Erc721, Origin, Test, USER_A, USER_B, USER_C};
+use super::*;
+use frame_support::{assert_noop, assert_ok};
+use sp_core::U256;
+
+#[test]
+fn mint_burn_tokens() {
+    new_test_ext().execute_with(|| {
+        let id_a: U256 = 1.into();
+        let id_b: U256 = 2.into();
+        let metadata_a: Vec<u8> = vec![1, 2, 3];
+        let metadata_b: Vec<u8> = vec![4, 5, 6];
+
+        assert_ok!(Erc721::mint(
+            Origin::root(),
+            USER_A,
+            id_a,
+            metadata_a.clone()
+        ));
+        assert_eq!(
+            Erc721::tokens(id_a).unwrap(),
+            Erc721Token {
+                id: id_a,
+                metadata: metadata_a.clone()
+            }
+        );
+        assert_eq!(Erc721::token_count(), 1.into());
+        assert_noop!(
+            Erc721::mint(Origin::root(), USER_A, id_a, metadata_a.clone()),
+            Error::<Test>::TokenAlreadyExists
+        );
+
+        assert_ok!(Erc721::mint(
+            Origin::root(),
+            USER_A,
+            id_b,
+            metadata_b.clone()
+        ));
+        assert_eq!(
+            Erc721::tokens(id_b).unwrap(),
+            Erc721Token {
+                id: id_b,
+                metadata: metadata_b.clone()
+            }
+        );
+        assert_eq!(Erc721::token_count(), 2.into());
+        assert_noop!(
+            Erc721::mint(Origin::root(), USER_A, id_b, metadata_b.clone()),
+            Error::<Test>::TokenAlreadyExists
+        );
+
+        assert_ok!(Erc721::burn(Origin::root(), id_a));
+        assert_eq!(Erc721::token_count(), 1.into());
+        assert!(!<Tokens>::contains_key(&id_a));
+        assert!(!<TokenOwner<Test>>::contains_key(&id_a));
+
+        assert_ok!(Erc721::burn(Origin::root(), id_b));
+        assert_eq!(Erc721::token_count(), 0.into());
+        assert!(!<Tokens>::contains_key(&id_b));
+        assert!(!<TokenOwner<Test>>::contains_key(&id_b));
+    })
+}
+
+#[test]
+fn transfer_tokens() {
+    new_test_ext().execute_with(|| {
+        let id_a: U256 = 1.into();
+        let id_b: U256 = 2.into();
+        let metadata_a: Vec<u8> = vec![1, 2, 3];
+        let metadata_b: Vec<u8> = vec![4, 5, 6];
+
+        assert_ok!(Erc721::mint(
+            Origin::root(),
+            USER_A,
+            id_a,
+            metadata_a.clone()
+        ));
+        assert_ok!(Erc721::mint(
+            Origin::root(),
+            USER_A,
+            id_b,
+            metadata_b.clone()
+        ));
+
+        assert_ok!(Erc721::transfer(Origin::signed(USER_A), USER_B, id_a));
+        assert_eq!(Erc721::owner_of(id_a).unwrap(), USER_B);
+
+        assert_ok!(Erc721::transfer(Origin::signed(USER_A), USER_C, id_b));
+        assert_eq!(Erc721::owner_of(id_b).unwrap(), USER_C);
+
+        assert_ok!(Erc721::transfer(Origin::signed(USER_B), USER_A, id_a));
+        assert_eq!(Erc721::owner_of(id_a).unwrap(), USER_A);
+
+        assert_ok!(Erc721::transfer(Origin::signed(USER_C), USER_A, id_b));
+        assert_eq!(Erc721::owner_of(id_b).unwrap(), USER_A);
+    })
+}


### PR DESCRIPTION
Added 3 new pallets to support ERC20 bridge:
* pallet-chainbridge
* pallet-erc721
* pallet-erc20

Pallets have been taken from [ChainSafe/chainbridge-substrate](https://github.com/ChainSafe/chainbridge-substrate) repo.