### PR TITLE
CBI-624 adjust treasury burn rate to 0

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -616,7 +616,7 @@ parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const ProposalBondMinimum: Balance = 1 * DOLLARS;
 	pub const SpendPeriod: BlockNumber = 1 * DAYS;
-	pub const Burn: Permill = Permill::from_percent(50);
+	pub const Burn: Permill = Permill::from_percent(0);
 	pub const TipCountdown: BlockNumber = 1 * DAYS;
 	pub const TipFindersFee: Percent = Percent::from_percent(20);
 	pub const TipReportDepositBase: Balance = 1 * DOLLARS;

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -412,7 +412,7 @@ fn unused_pot_should_diminish() {
 		assert_eq!(Balances::total_issuance(), init_total_issuance + 100);
 
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
-		assert_eq!(Treasury::pot(), 50);
+		assert_eq!(Treasury::pot(), 100);
 		assert_eq!(Balances::total_issuance(), init_total_issuance + 50);
 	});
 }
@@ -427,7 +427,7 @@ fn rejected_spend_proposal_ignored_on_spend_period() {
 
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Balances::free_balance(3), 0);
-		assert_eq!(Treasury::pot(), 50);
+		assert_eq!(Treasury::pot(), 100);
 	});
 }
 
@@ -497,7 +497,7 @@ fn pot_underflow_should_not_diminish() {
 		let _ = Balances::deposit_into_existing(&Treasury::account_id(), 100).unwrap();
 		<Treasury as OnInitialize<u64>>::on_initialize(4);
 		assert_eq!(Balances::free_balance(3), 150); // Fund has been spent
-		assert_eq!(Treasury::pot(), 25); // Pot has finally changed
+		assert_eq!(Treasury::pot(), 50); // Pot has finally changed
 	});
 }
 
@@ -682,7 +682,7 @@ fn approve_bounty_works() {
 			bond: deposit,
 			status: BountyStatus::Funded,
 		});
-		assert_eq!(Treasury::pot(), 100 - 50 - 25); // burn 25
+		assert_eq!(Treasury::pot(), 100 - 50 - 0); // burn 25
 		assert_eq!(Balances::free_balance(Treasury::bounty_account_id(0)), 50);
 	});
 }
@@ -911,7 +911,7 @@ fn cancel_and_refund() {
 
 		assert_ok!(Treasury::close_bounty(Origin::root(), 0));
 
-		assert_eq!(Treasury::pot(), 85); // - 25 + 10
+		assert_eq!(Treasury::pot(), 110); // - 25 + 10
 	});
 }
 

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -127,7 +127,7 @@ parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const ProposalBondMinimum: u64 = 1;
 	pub const SpendPeriod: u64 = 2;
-	pub const Burn: Permill = Permill::from_percent(50);
+	pub const Burn: Permill = Permill::from_percent(0);
 	pub const TipCountdown: u64 = 1;
 	pub const TipFindersFee: Percent = Percent::from_percent(20);
 	pub const TipReportDepositBase: u64 = 1;

--- a/frame/treasury/src/tests.rs
+++ b/frame/treasury/src/tests.rs
@@ -413,7 +413,7 @@ fn unused_pot_should_diminish() {
 
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 100);
-		assert_eq!(Balances::total_issuance(), init_total_issuance + 50);
+		assert_eq!(Balances::total_issuance(), init_total_issuance + 100);
 	});
 }
 


### PR DESCRIPTION
This PR adjusts the burn rate to Perbill::0 computed weight reducing from the previous burn rate of 50% after the spending period has concluded