### PR TITLE
CBI-708-encode_report_metrics: encode arguments

### DIFF
--- a/frame/example-offchain-worker/src/lib.rs
+++ b/frame/example-offchain-worker/src/lib.rs
@@ -480,11 +480,19 @@ impl<T: Trait> Module<T> {
 		Ok(())
 	}
 
-	// fn parse_topology(topology_str: &str) -> Result<(), http::Error> {
-	// 	let val = lite_json::parse_json(topology_str).ok();
-
-	// 	Ok(())
-
+    fn encode_report_metrics(
+        app_id: T::AccountId,
+        day_start_ms: u64,
+        stored_bytes: u128,
+        requests: u128,
+    ) -> Vec<u8> {
+        let mut call_data = REPORT_METRICS_SELECTOR.to_vec();
+        app_id.encode_to(&mut call_data);
+        day_start_ms.encode_to(&mut call_data);
+        stored_bytes.encode_to(&mut call_data);
+        requests.encode_to(&mut call_data);
+        call_data
+    }
 }
 
 

--- a/frame/example-offchain-worker/src/tests/mod.rs
+++ b/frame/example-offchain-worker/src/tests/mod.rs
@@ -52,6 +52,18 @@ fn test_contract_api() {
     assert_eq!(REPORT_METRICS_SELECTOR.to_vec(), selector);
 }
 
+#[test]
+fn test_encode_report_metrics() {
+    let call_data = ExampleOffchainWorker::encode_report_metrics(AccountId::from_raw([2; 32]), 3, 4, 5);
+    assert_eq!(call_data, vec![
+        53, 50, 11, 190, // Selector
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // 32 bytes, app_id
+        3, 0, 0, 0, 0, 0, 0, 0, // 8 bytes, day_start_ms
+        4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 16 bytes, stored_bytes
+        5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 16 bytes, requests
+    ]);
+}
+
 fn build_ext() -> sp_io::TestExternalities {
     build_ext_for_contracts()
 }


### PR DESCRIPTION
Simple encoding of contract function arguments using SCALE codec.