### PR TITLE
[CBI-1563] enable inflation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0]
+### Changed
+- Enabled inflation
+
 ## [2.7.0]
 ### Changed
 - Bonding period set to 3 eras, SlashDeferDuration set to 2 eras

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 276,
+	spec_version: 277,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -429,11 +429,11 @@ impl pallet_session::historical::Trait for Runtime {
 pallet_staking_reward_curve::build! {
 	const REWARD_CURVE: PiecewiseLinear<'static> = curve!(
 		min_inflation: 0_000_100,
-		max_inflation: 0_002_555,
-		ideal_stake: 0_200_000,
+		max_inflation: 0_013_000,
+		ideal_stake: 0_100_000,
 		falloff: 0_050_000,
-		max_piece_count: 350,
-		test_precision: 0_185_000,
+		max_piece_count: 100,
+		test_precision: 0_050_000,
 	);
 }
 

--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 274,
+	spec_version: 276,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -426,11 +426,16 @@ impl pallet_session::historical::Trait for Runtime {
 	type FullIdentificationOf = pallet_staking::ExposureOf<Runtime>;
 }
 
-const ZeroPercent: Perbill = Perbill::from_percent(0);
-const REWARD_CURVE: PiecewiseLinear<'static> = PiecewiseLinear {
-	points: &[(ZeroPercent, ZeroPercent)],
-	maximum: ZeroPercent,
-};
+pallet_staking_reward_curve::build! {
+	const REWARD_CURVE: PiecewiseLinear<'static> = curve!(
+		min_inflation: 0_000_100,
+		max_inflation: 0_002_555,
+		ideal_stake: 0_200_000,
+		falloff: 0_050_000,
+		max_piece_count: 350,
+		test_precision: 0_185_000,
+	);
+}
 
 parameter_types! {
 	pub const SessionsPerEra: sp_staking::SessionIndex = 6;


### PR DESCRIPTION
Enabled inflation. APR at x_ideal is 13%.

`test_precision` has been increased to support our inflation. It is not an issue. [Confirmed](https://matrix.to/#/!HzySYSaIhtyWrwiwEV:matrix.org/$164268003514623CHUnf:matrix.parity.io?via=matrix.parity.io&via=corepaper.org&via=matrix.org) with Paritytech team.