### PR TITLE
Changelog entry on a new spec_version format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Node runtime extended with `ddc-staking` pallet
+- New `spec_version` format. Mainnet runtime specification upgrade increments the third digit and resets two least significant digits now. Other upgrades should update these two least significant digits only.
 
 ## [2.33.0]
 ### Changed


### PR DESCRIPTION
New `spec_version` format was introduced by https://github.com/Cerebellum-Network/pos-network-node/pull/191/commits/bdb9a79192fdcc818dbc0fb7a0f290afa8673780 in https://github.com/Cerebellum-Network/pos-network-node/pull/191. However `CHANGELOG.md` does not explain or mention this significant versioning format update. This is the `fix` update to describe the new format for the `spec_version` in the `CHANGELOG.md`.